### PR TITLE
Add a default item image path

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,10 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || process.env.PUBLIC_URL + "/placeholder.png"}
+                src={
+                  this.props.item.image ||
+                  process.env.PUBLIC_URL + "/placeholder.png"
+                }
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || process.env.PUBLIC_URL + "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || process.env.PUBLIC_URL + "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
- #INC-5312
- Add a default path in Item/index.js for the screen immediately
  following item creation
- Add a default path in ItemPreview for viewing on the home screen

<img width="1440" alt="Screen Shot 2022-07-26 at 8 50 10 PM" src="https://user-images.githubusercontent.com/9872086/181137665-4a8937e4-4f34-4522-896a-0bcdd5a87ad4.png">
<img width="1440" alt="Screen Shot 2022-07-26 at 8 55 18 PM" src="https://user-images.githubusercontent.com/9872086/181137709-74db887f-895c-4433-80c0-7215c36a7946.png">

