### PR TITLE
Add filter to items using title params

### DIFF
--- a/backend/app/controllers/items_controller.rb
+++ b/backend/app/controllers/items_controller.rb
@@ -16,6 +16,10 @@ class ItemsController < ApplicationController
 
     @items = @items.order(created_at: :desc).offset(params[:offset] || 0).limit(params[:limit] || 100)
 
+    if(params[:title])
+      @items = @items.select { |item| item.title.downcase.include? params[:title].downcase }
+    end
+
     render json: {
       items: @items.map { |item|
         {


### PR DESCRIPTION
- Add product filtering support to backend
- Add a query filter called "title" when retrieving items using GET request
- The backend should show all relevant items whose title contains the
  same title query

Part one of adding search - this is the backend filtering in the items index controller.